### PR TITLE
chore(release): 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.1.0] - 2025-10-05
+## [0.1.2] - 2025-10-05
+### Changed
+- Removed C++/CUDA backend files and extern; Python-only package
+- Added new examples with visualizations; updated README
+- Switched CI to release-only deploy and verified 0.1.1 publish
+
 ### Added
 - Xavier/He initializers in `Linear` layer and documentation
 - Basic pytest suite covering Tensor, Linear, and SGD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nnetflow"
-version = "0.1.1"  
+version = "0.1.2"  
 description = "A minimal neural network framework with autodiff and NumPy"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="nnetflow",
-    version="0.1.0",
+    version="0.1.2",
     description="A minimal neural network framework with autodiff and NumPy",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Bump version to 0.1.2, update CHANGELOG. Removes C++/CUDA backend, adds examples, and docs tweaks.