### PR TITLE
Fix Tensor helper methods conflict with numpy API (issue #39)

### DIFF
--- a/nnetflow/engine.py
+++ b/nnetflow/engine.py
@@ -28,7 +28,6 @@ class Tensor:
             data = data.astype(np.float64)
         
         self.data = data
-        self.shape = self.data.shape
         self._op = _op
         self._prev: Set['Tensor'] = set(c for c in _children if isinstance(c, Tensor))
 
@@ -576,16 +575,32 @@ class Tensor:
         if out.requires_grad:
             out._backward = _backward
         return out
+
+    # --- Shape / size helpers ---
+
+    @property
     def shape(self) -> Tuple[int, ...]:
+        """Return the shape of the underlying data (tuple of ints)."""
         return self.data.shape
+
+    @property
     def size(self) -> int:
-        return self.data.size
+        """Total number of elements in the tensor (alias for ``numel``)."""
+        return int(self.data.size)
+
+    @property
     def ndim(self) -> int:
-        return self.data.ndim
+        """Number of dimensions of the tensor."""
+        return int(self.data.ndim)
+
     def numel(self) -> int:
-        return self.data.numel
+        """PyTorch-style alias for the total number of elements in the tensor."""
+        return int(self.data.size)
+
     def dim(self) -> int:
-        return self.data.dim()
+        """PyTorch-style alias for the number of dimensions of the tensor."""
+        return int(self.data.ndim)
+
     def bool(self) -> 'Tensor':
         """
         Casts the tensor's data to a boolean data type.

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -31,6 +31,20 @@ class TestTensorBasic:
         assert not t2.requires_grad
         assert t2.grad is None
 
+    def test_tensor_shape_size_ndim_numel_dim_helpers(self):
+        """Tensor helper APIs delegate correctly to underlying numpy array."""
+        data = np.random.randn(2, 3, 4)
+        t = Tensor(data)
+
+        # Attribute-style helpers
+        assert t.shape == data.shape
+        assert t.size == data.size
+        assert t.ndim == data.ndim
+
+        # Method-style helpers
+        assert t.numel() == data.size
+        assert t.dim() == data.ndim
+
 
 class TestTensorArithmetic:
     """Test Tensor arithmetic operations."""


### PR DESCRIPTION
This PR fixes the Tensor helper methods that conflicted with numpy and instance attributes.\n\nChanges:\n- Remove the redundant  instance attribute and introduce property-based helpers: , , .\n- Re-implement  and  to delegate to  and  instead of non-existent numpy attributes.\n- Add tests in  to verify these helpers mirror the underlying numpy array behavior.\n\nAll tests pass in the project test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced tensor information access with new properties (`shape`, `size`, `ndim`) and methods (`numel()`, `dim()`) for querying tensor dimensions and element counts
  * Added `bool()` method for casting tensors to boolean type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->