### PR TITLE
Declare SciPy runtime dependency for GELU (issue #25)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,11 @@ license = { text = "MIT" }
 authors = [
   { name = "Lewis Njue", email = "lewiskinyuanjue.ke@gmail.com" }
 ]
-dependencies = ["numpy"]
+# Runtime dependencies (engine.gelu and experimental activations require SciPy)
+dependencies = [
+  "numpy",
+  "scipy>=1.9",
+]
 
 keywords = [
   "neural network",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
     author_email="lewiskinyuanjue.ke@gmail.com",
     url="https://github.com/lewisnjue/nnetflow",
     packages=find_packages(),
-    install_requires=["numpy"],
+    # Keep in sync with pyproject.toml dependencies
+    install_requires=["numpy", "scipy>=1.9"],
     python_requires=">=3.8",
     include_package_data=True,
     classifiers=[

--- a/tests/test_gelu_dependency.py
+++ b/tests/test_gelu_dependency.py
@@ -1,0 +1,25 @@
+"""Tests that GELU implementations run successfully (SciPy present).
+
+These tests don't directly assert packaging metadata, but they
+exercise the code paths that depend on SciPy so that missing
+SciPy would show up as an ImportError at test time.
+"""
+
+import numpy as np
+
+from nnetflow.engine import Tensor
+from nnetflow.experimental import activations as exp_act
+
+
+def test_engine_gelu_runs():
+    x = Tensor(np.array([0.0, 1.0, -1.0]))
+    y = x.gelu()
+
+    assert y.shape == x.shape
+
+
+def test_experimental_gelu_runs():
+    x = np.array([0.0, 1.0, -1.0])
+    y = exp_act.GELU(x)
+
+    assert y.shape == x.shape


### PR DESCRIPTION
This PR fixes the packaging bug where SciPy was required at runtime but not declared as a dependency.

Changes:
- Add `scipy>=1.9` to `[project.dependencies]` in `pyproject.toml`.
- Add `scipy>=1.9` to `install_requires` in `setup.py` (kept in sync with pyproject).
- Add `tests/test_gelu_dependency.py` to exercise GELU code paths in `engine.gelu` and `experimental.activations.GELU`, so missing SciPy would surface as an ImportError during tests.

All tests pass in the project test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to include SciPy 1.9+ as a required package

* **Tests**
  * Added tests to verify GELU implementations execute correctly and preserve tensor shapes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->