### PR TITLE
Fix Tensor.view tuple handling (issue #27)

### DIFF
--- a/nnetflow/engine.py
+++ b/nnetflow/engine.py
@@ -655,11 +655,20 @@ class Tensor:
             
         return out
     
-    def view(self,new_shape):  # mybad :( i am inefficient but that okay 
+    def view(self, *new_shape):  # mybad :( i am inefficient but that okay 
         """ 
-        reshape the tensor to the new shape but creates a new tensor not efficient  
+        Reshape the tensor using a view-like API.
+
+        This is a thin wrapper around :meth:`reshape` that accepts a
+        variable number of dimensions or a single tuple, e.g.::
+
+            x.view(2, 3)
+            x.view((2, 3))
         """ 
-        return self.reshape(new_shape)
+        # Support either x.view(2, 3) or x.view((2, 3))
+        if len(new_shape) == 1 and isinstance(new_shape[0], (tuple, list)):
+            new_shape = tuple(new_shape[0])
+        return self.reshape(*new_shape)
 
     def transpose(self, axes: Optional[Tuple[int, ...]] = None) -> 'Tensor':
         """ 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -267,6 +267,19 @@ class TestTensorReductions:
         np.testing.assert_allclose(t_var_1.data, np_var_1, rtol=1e-6, atol=1e-8)
         np.testing.assert_allclose(t_std_1.data, np_std_1, rtol=1e-6, atol=1e-8)
 
+    def test_view_behaves_like_reshape_and_supports_tuple(self):
+        """Tensor.view should match reshape semantics and accept tuple or varargs."""
+        data = np.arange(12, dtype=float)
+        x = Tensor(data.copy(), requires_grad=False)
+
+        v1 = x.view(3, 4)
+        v2 = x.view((3, 4))
+        v3 = x.view(2, -1)
+
+        np.testing.assert_allclose(v1.data, data.reshape(3, 4))
+        np.testing.assert_allclose(v2.data, data.reshape(3, 4))
+        np.testing.assert_allclose(v3.data, data.reshape(2, -1))
+
 
 class TestTensorMatmul:
     """Test matrix multiplication."""


### PR DESCRIPTION
This PR fixes the Tensor.view implementation so it correctly unpacks shape arguments and matches reshape behavior.

Changes:
- Update Tensor.view to accept either varargs (x.view(2, 3)) or a single tuple (x.view((2, 3))) and forward them to reshape as varargs.
- Add a unit test in tests/test_engine.py::TestTensorReductions::test_view_behaves_like_reshape_and_supports_tuple to ensure view matches NumPy reshape, including -1 inference.

All tests pass locally with pytest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `Tensor.view` method to accept flexible input formats, supporting both separate dimension arguments (e.g., `view(2, 3)`) and tuple syntax (e.g., `view((2, 3))`) for improved API usability.

* **Tests**
  * Added test coverage verifying consistent behavior across different input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->